### PR TITLE
canfdの更新 & odriveと一緒に分離

### DIFF
--- a/playbooks/04-actuator-drivers.yaml
+++ b/playbooks/04-actuator-drivers.yaml
@@ -1,0 +1,5 @@
+- name: Set up actuator drivers
+  hosts: targets
+  roles:
+    - role: odrive
+    - role: canfd

--- a/playbooks/04-actuator-drivers.yaml
+++ b/playbooks/04-actuator-drivers.yaml
@@ -1,5 +1,10 @@
-- name: Set up actuator drivers
+- name: Set up actuator drivers for Ubuntu 22.04/24.04
   hosts: targets
+  pre_tasks:
+    - name: Verify OS
+      ansible.builtin.fail:
+        msg: Only Ubuntu 22.04 / 24.04 is supported
+      when: ansible_distribution != 'Ubuntu' or (ansible_distribution_version != '22.04' and ansible_distribution_version != '24.04')
   roles:
     - role: odrive
     - role: canfd

--- a/playbooks/05-vision-sdks.yaml
+++ b/playbooks/05-vision-sdks.yaml
@@ -1,4 +1,4 @@
-- name: Set up device SDK for Ubuntu 22.04
+- name: Set up vision sensor SDKs for Ubuntu 22.04
   hosts: targets
   pre_tasks:
     - name: Verify OS
@@ -12,7 +12,6 @@
           - rosdistro: "{{ rosdistro }}"
           - rmw_implementation: "{{ rmw_implementation }}"
   roles:
-    - role: odrive
     - role: realsense
     - role: azure_kinect
       when: ansible_distribution_version == '22.04' # Only supported on Ubuntu 22.04

--- a/playbooks/99-raspberry_pi.yaml
+++ b/playbooks/99-raspberry_pi.yaml
@@ -3,5 +3,4 @@
   become: true
   roles:
     - role: disable_unwanted_service
-    - role: canfd
     - role: canfd_pi

--- a/roles/canfd/files/90-canbus-altname.sh
+++ b/roles/canfd/files/90-canbus-altname.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# $1 = カーネル名 (例: can0)
+# $2 = ハードウェアID (例: 00112233)
+ORIG_NAME=$1
+HW_ID=$2
+
+LOGFILE="/var/log/assign_can_altname.log"
+LOCKFILE="/var/tmp/can_altname.lock"
+
+if [ -z "$ORIG_NAME" ] || [ -z "$HW_ID" ]; then
+    echo "$(date): Error - Missing arguments" >> "$LOGFILE"
+    exit 1
+fi
+
+(
+    # 排他制御
+    flock -w 5 9 || { echo "$(date): Failed to acquire lock" >> "$LOGFILE"; exit 1; }
+
+    PARENT_NET_DIR="/sys/class/net/$ORIG_NAME/device/net"
+    CH_INDEX=0
+    CH_TOTAL=1
+
+    # チャンネル総数と現在のチャンネルインデックスを特定
+    if [ -d "$PARENT_NET_DIR" ]; then
+        CAN_DEVS=$(ls "$PARENT_NET_DIR" | grep '^can' | sort -V)
+        CH_TOTAL=$(echo "$CAN_DEVS" | grep -c '^can')
+
+        for dev in $CAN_DEVS; do
+            if [ "$dev" = "$ORIG_NAME" ]; then
+                break
+            fi
+            CH_INDEX=$((CH_INDEX + 1))
+        done
+    fi
+
+    # ---------------------------------------------------------
+    # <iSerial>(<n個目のデバイス>)c<channel> フォーマットの生成
+    # ---------------------------------------------------------
+    COUNTER=0
+    while true; do
+        # 1台目はサフィックスなし、2台目以降は (1), (2)... を付与
+        if [ "$COUNTER" -eq 0 ]; then
+            DEV_SUFFIX=""
+        else
+            DEV_SUFFIX=".${COUNTER}"
+        fi
+
+        # チャンネル総数に応じて末尾のフォーマットを切り替え
+        if [ "$CH_TOTAL" -gt 1 ]; then
+            TARGET_ALTNAME="${HW_ID}${DEV_SUFFIX}c${CH_INDEX}"
+        else
+            TARGET_ALTNAME="${HW_ID}${DEV_SUFFIX}"
+        fi
+
+        # 生成した altname がシステム上に存在しないか確認
+        ip link show dev "$TARGET_ALTNAME" >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            # 存在しないため、この名前に決定してループを抜ける
+            break
+        fi
+
+        # 既に存在する場合は次の連番へ
+        COUNTER=$((COUNTER + 1))
+        if [ "$COUNTER" -gt 10 ]; then
+            echo "$(date): Error - Too many identical IDs (${HW_ID})" >> "$LOGFILE"
+            exit 1
+        fi
+    done
+
+    # 決定した altname を付与
+    /sbin/ip link property add dev "$ORIG_NAME" altname "$TARGET_ALTNAME"
+
+
+
+    if [ $? -eq 0 ]; then
+        echo "$(date): Success - Assigned $TARGET_ALTNAME to $ORIG_NAME" >> "$LOGFILE"
+    else
+        echo "$(date): Error - Failed to Assign altname to $ORIG_NAME" >> "$LOGFILE"
+    fi
+
+) 9> "$LOCKFILE"

--- a/roles/canfd/files/90-canbus-altname.sh
+++ b/roles/canfd/files/90-canbus-altname.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
+set -euo pipefail
 
 # $1 = カーネル名 (例: can0)
 # $2 = ハードウェアID (例: 00112233)
-ORIG_NAME=$1
-HW_ID=$2
+ORIG_NAME=${1-}
+HW_ID=${2-}
 
-LOGFILE="/var/log/assign_can_altname.log"
 LOCKFILE="/var/tmp/can_altname.lock"
 
 if [ -z "$ORIG_NAME" ] || [ -z "$HW_ID" ]; then
-    echo "$(date): Error - Missing arguments" >> "$LOGFILE"
+    logger -t assign_can_altname "Error - Missing arguments"
     exit 1
 fi
 
 (
     # 排他制御
-    flock -w 5 9 || { echo "$(date): Failed to acquire lock" >> "$LOGFILE"; exit 1; }
+    flock -w 5 9 || { logger -t assign_can_altname "Failed to acquire lock"; exit 1; }
 
     PARENT_NET_DIR="/sys/class/net/$ORIG_NAME/device/net"
     CH_INDEX=0
@@ -23,8 +23,8 @@ fi
 
     # チャンネル総数と現在のチャンネルインデックスを特定
     if [ -d "$PARENT_NET_DIR" ]; then
-        CAN_DEVS=$(ls "$PARENT_NET_DIR" | grep '^can' | sort -V)
-        CH_TOTAL=$(echo "$CAN_DEVS" | grep -c '^can')
+        CAN_DEVS=$(ls "$PARENT_NET_DIR" | grep '^can' | sort -V || true)
+        CH_TOTAL=$(echo "$CAN_DEVS" | grep -c '^can' || true)
 
         for dev in $CAN_DEVS; do
             if [ "$dev" = "$ORIG_NAME" ]; then
@@ -39,7 +39,7 @@ fi
     # ---------------------------------------------------------
     COUNTER=0
     while true; do
-        # 1台目はサフィックスなし、2台目以降は (1), (2)... を付与
+        # 1台目はサフィックスなし、2台目以降は .1, .2 ... を付与
         if [ "$COUNTER" -eq 0 ]; then
             DEV_SUFFIX=""
         else
@@ -54,8 +54,7 @@ fi
         fi
 
         # 生成した altname がシステム上に存在しないか確認
-        ip link show dev "$TARGET_ALTNAME" >/dev/null 2>&1
-        if [ $? -ne 0 ]; then
+        if ! /usr/sbin/ip link show dev "$TARGET_ALTNAME" >/dev/null 2>&1; then
             # 存在しないため、この名前に決定してループを抜ける
             break
         fi
@@ -63,20 +62,16 @@ fi
         # 既に存在する場合は次の連番へ
         COUNTER=$((COUNTER + 1))
         if [ "$COUNTER" -gt 10 ]; then
-            echo "$(date): Error - Too many identical IDs (${HW_ID})" >> "$LOGFILE"
+            logger -t assign_can_altname "Error - Too many identical IDs (${HW_ID})"
             exit 1
         fi
     done
 
     # 決定した altname を付与
-    /sbin/ip link property add dev "$ORIG_NAME" altname "$TARGET_ALTNAME"
-
-
-
-    if [ $? -eq 0 ]; then
-        echo "$(date): Success - Assigned $TARGET_ALTNAME to $ORIG_NAME" >> "$LOGFILE"
+    if /usr/sbin/ip link property add dev "$ORIG_NAME" altname "$TARGET_ALTNAME"; then
+        logger -t assign_can_altname "Success - Assigned $TARGET_ALTNAME to $ORIG_NAME"
     else
-        echo "$(date): Error - Failed to Assign altname to $ORIG_NAME" >> "$LOGFILE"
+        logger -t assign_can_altname "Error - Failed to Assign altname to $ORIG_NAME"
     fi
 
 ) 9> "$LOCKFILE"

--- a/roles/canfd/files/90-canbus-altname.sh
+++ b/roles/canfd/files/90-canbus-altname.sh
@@ -9,13 +9,13 @@ HW_ID=${2-}
 LOCKFILE="/var/tmp/can_altname.lock"
 
 if [ -z "$ORIG_NAME" ] || [ -z "$HW_ID" ]; then
-    logger -t assign_can_altname "Error - Missing arguments"
+    /usr/bin/logger -t assign_can_altname "Error - Missing arguments"
     exit 1
 fi
 
 (
     # 排他制御
-    flock -w 5 9 || { logger -t assign_can_altname "Failed to acquire lock"; exit 1; }
+    /usr/bin/flock -w 5 9 || { /usr/bin/logger -t assign_can_altname "Failed to acquire lock"; exit 1; }
 
     PARENT_NET_DIR="/sys/class/net/$ORIG_NAME/device/net"
     CH_INDEX=0
@@ -23,8 +23,8 @@ fi
 
     # チャンネル総数と現在のチャンネルインデックスを特定
     if [ -d "$PARENT_NET_DIR" ]; then
-        CAN_DEVS=$(ls "$PARENT_NET_DIR" | grep '^can' | sort -V || true)
-        CH_TOTAL=$(echo "$CAN_DEVS" | grep -c '^can' || true)
+        CAN_DEVS=$(/usr/bin/ls "$PARENT_NET_DIR" | /usr/bin/grep '^can' | /usr/bin/sort -V || true)
+        CH_TOTAL=$(echo "$CAN_DEVS" | /usr/bin/grep -c '^can' || true)
 
         for dev in $CAN_DEVS; do
             if [ "$dev" = "$ORIG_NAME" ]; then
@@ -62,16 +62,16 @@ fi
         # 既に存在する場合は次の連番へ
         COUNTER=$((COUNTER + 1))
         if [ "$COUNTER" -gt 10 ]; then
-            logger -t assign_can_altname "Error - Too many identical IDs (${HW_ID})"
+            /usr/bin/logger -t assign_can_altname "Error - Too many identical IDs (${HW_ID})"
             exit 1
         fi
     done
 
     # 決定した altname を付与
     if /usr/sbin/ip link property add dev "$ORIG_NAME" altname "$TARGET_ALTNAME"; then
-        logger -t assign_can_altname "Success - Assigned $TARGET_ALTNAME to $ORIG_NAME"
+        /usr/bin/logger -t assign_can_altname "Success - Assigned $TARGET_ALTNAME to $ORIG_NAME"
     else
-        logger -t assign_can_altname "Error - Failed to Assign altname to $ORIG_NAME"
+        /usr/bin/logger -t assign_can_altname "Error - Failed to Assign altname to $ORIG_NAME"
     fi
 
 ) 9> "$LOCKFILE"

--- a/roles/canfd/files/90-canbus.rules
+++ b/roles/canfd/files/90-canbus.rules
@@ -1,5 +1,5 @@
 # set altname
-SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", ATTRS{serial}=="?*", ATTRS{manufacturer}=="ForteFibre", RUN+="/bin/bash /etc/udev/rules.d/90-canbus-altname.sh %k $attr{serial}"
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", ATTRS{serial}=="?*", ATTRS{manufacturer}=="ForteFibre", RUN+="/etc/udev/rules.d/90-canbus-altname.sh %k $attr{serial}"
 
 # link up
 SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", RUN+="/usr/sbin/ip link set %k up type can bitrate 500000 sample-point 0.750 dbitrate 4000000 dsample-point 0.800 fd on restart-ms 500"

--- a/roles/canfd/files/90-canbus.rules
+++ b/roles/canfd/files/90-canbus.rules
@@ -1,0 +1,5 @@
+# set altname
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", ATTRS{serial}=="?*", ATTRS{manufacturer}=="ForteFibre", RUN+="/bin/bash /etc/udev/rules.d/90-canbus-altname.sh %k $attr{serial}"
+
+# link up
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", RUN+="/usr/sbin/ip link set %k up type can bitrate 500000 dbitrate 4000000 fd on"

--- a/roles/canfd/files/90-canbus.rules
+++ b/roles/canfd/files/90-canbus.rules
@@ -2,4 +2,4 @@
 SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", ATTRS{serial}=="?*", ATTRS{manufacturer}=="ForteFibre", RUN+="/bin/bash /etc/udev/rules.d/90-canbus-altname.sh %k $attr{serial}"
 
 # link up
-SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", RUN+="/usr/sbin/ip link set %k up type can bitrate 500000 dbitrate 4000000 fd on"
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="can*", RUN+="/usr/sbin/ip link set %k up type can bitrate 500000 sample-point 0.750 dbitrate 4000000 dsample-point 0.800 fd on restart-ms 500"

--- a/roles/canfd/handlers/main.yaml
+++ b/roles/canfd/handlers/main.yaml
@@ -1,0 +1,4 @@
+- name: Reload udev rules
+  ansible.builtin.command: udevadm control --reload-rules
+  become: true
+  changed_when: true

--- a/roles/canfd/tasks/main.yaml
+++ b/roles/canfd/tasks/main.yaml
@@ -26,3 +26,15 @@
     state: stopped
     masked: true
   become: true
+- name: Copy CAN bus udev rules
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/90-canbus.rules"
+    dest: /etc/udev/rules.d/90-canbus.rules
+    mode: "0644"
+  become: true
+- name: Copy CAN bus altname script
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/90-canbus-altname.sh"
+    dest: /etc/udev/rules.d/90-canbus-altname.sh
+    mode: "0755"
+  become: true

--- a/roles/canfd/tasks/main.yaml
+++ b/roles/canfd/tasks/main.yaml
@@ -1,20 +1,3 @@
-- name: Add systemd managed CAN interface
-  ansible.builtin.blockinfile:
-    path: /etc/systemd/network/80-can.network
-    create: true
-    mode: "0644"
-    block: |
-      [Match]
-      Name=can*
-
-      [CAN]
-      BitRate=500000
-      FDMode=yes
-      SamplePoint=75%
-      DataBitRate=4000000
-      DataSamplePoint=80%
-      RestartSec=0.5s
-  become: true
 - name: Add CAN utils
   ansible.builtin.apt:
     name: can-utils

--- a/roles/canfd/tasks/main.yaml
+++ b/roles/canfd/tasks/main.yaml
@@ -15,9 +15,11 @@
     dest: /etc/udev/rules.d/90-canbus.rules
     mode: "0644"
   become: true
+  notify: Reload udev rules
 - name: Copy CAN bus altname script
   ansible.builtin.copy:
     src: "{{ role_path }}/files/90-canbus-altname.sh"
     dest: /etc/udev/rules.d/90-canbus-altname.sh
     mode: "0755"
   become: true
+  notify: Reload udev rules


### PR DESCRIPTION
## Summary
- `canfd` と `odrive` を `04-actuator-drivers.yaml` playbook に分離
- CAN インターフェース名の一意化のため udev rules と altname 割り当てスクリプトを追加
  - シリアル番号ベースで安定した altname を付与し、複数チャンネル・複数デバイス構成に対応
- systemd-networkd による CAN 管理をやめ、udev rule 側で link up とパラメータ設定 (bitrate/sample-point/dbitrate/dsample-point/fd/restart-ms) を一元化
- altname 割り当てスクリプトを堅牢化 (`set -euo pipefail`, `/usr/sbin/ip` 統一, `logger` 化)

## Test plan
- [ ] Ubuntu 上で playbook を実行して canfd ロールが完走することを確認
- [ ] ForteFibre 製 CAN デバイス接続時に altname が付与されることを確認
- [ ] link up 後に bitrate/dbitrate/FD モードが期待どおりであることを `ip -details link show` で確認